### PR TITLE
Feature/listado pedidos usuario

### DIFF
--- a/mobilemart/templates/mobilemart/listadopedidos.html
+++ b/mobilemart/templates/mobilemart/listadopedidos.html
@@ -4,5 +4,28 @@
 {% block title %}Listado pedidos{% endblock %}
 
 {% block contenido %}
-
+<section>
+    <div class="container mt-3 mb-5">
+        <h2 class="border-bottom">Listado de Pedidos</h2>
+        <div class="row">
+            {% for pedido in pedidos %}
+            <div class="col-md-6">
+                <div class="card border-primary mb-3">
+                    <div class="card-header bg-dark text-white">
+                        <h4 class="mb-0">Pedido #{{ pedido.id }}</h4>
+                    </div>
+                    <div class="card-body">
+                        <h5 class="card-title">Estado: {{ pedido.estado }}</h5>
+                        <p class="card-text">
+                            <strong>Usuario:</strong> {{ pedido.usuario.username }}<br>
+                            <strong>Producto:</strong> {% for detalle in pedido.detalles.all %}{{ detalle.celular.modelo }} {% endfor %}
+                        </p>
+                        <a href="{% url 'detallepedido' pedido.id %}" class="btn btn-dark">Ver Detalles</a>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+</section>
 {% endblock contenido %}

--- a/mobilemart/templates/mobilemart/listadousuarios.html
+++ b/mobilemart/templates/mobilemart/listadousuarios.html
@@ -14,5 +14,60 @@
 
 
     {% block contenido %}
-    
+    <div class="container mt-4">
+        <h1 class="border-bottom pb-3">Listado de usuarios</h1>
+        <div class="container mt-4">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>Rut</th>
+                        <th>Nombre</th>
+                        <th>Usuario</th>
+                        <th>Email</th>
+                        <th>Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for u in usuarios %}
+                    <tr>
+                        <td>{{ u.rut }}</td>
+                        <td>{{ u.nombre }} {{ u.apellido }}</td>
+                        <td>{{ u.username }}</td>
+                        <td>{{ u.email }}</td>
+                        <td>
+                            <a href="{% url 'detalleusuario' pk=u.pk %}">
+                                <button class="btn btn-dark">Editar</button>
+                            </a>
+                            {% if not u.is_superuser %}
+                            <form method="post" action="{% url 'eliminarusuario' pk=u.pk %}" style="display:inline;" id="delete-form-{{ u.pk }}">
+                                {% csrf_token %}
+                                <button type="button" class="btn btn-danger ms-2" onclick="confirmDelete('{{ u.pk }}')">Eliminar</button>
+                            </form>
+                            <button class="btn btn-warning ms-2" onclick="suspenderUsuario()">Suspender</button>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <script>
+        function confirmDelete(pk) {
+            Swal.fire({
+                title: '¿Estás seguro?',
+                text: "El usuario será eliminado permanentemente.",
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#dc3545',
+                confirmButtonText: 'Sí, eliminarlo',
+                cancelButtonText: 'Cancelar'
+            }).then(function(result) {
+                if (result.isConfirmed) {
+                    document.getElementById('delete-form-' + pk).submit();
+                }
+            })
+        }
+    </script>
     {% endblock contenido %}


### PR DESCRIPTION
feat: agregar vista de listado de usuarios en panel de administración

Se añadió plantilla para mostrar y gestionar usuarios:

    Extiende de mobilemart/baseadmin.html y carga etiquetas static.

    Define bloque title como “Listado usuarios”.

    En bloque contenido, incorpora un contenedor con tabla Bootstrap (table-hover) listando Rut, Nombre, Usuario, Email y Acciones.

    Itera sobre usuarios con {% for u in usuarios %} para poblar filas.

    Incluye botones “Editar” (enlace a detalleusuario) y, si el usuario no es superusuario, botón “Eliminar” con formulario POST a eliminarusuario y botón “Suspender”.

    Agrega script confirmDelete(pk) usando SweetAlert2 para confirmar eliminación antes de enviar el formulario.