### PR TITLE
Añadir estructura y estilo al listado de pedidos

### DIFF
--- a/mobilemart/templates/mobilemart/listadopedidos.html
+++ b/mobilemart/templates/mobilemart/listadopedidos.html
@@ -4,5 +4,28 @@
 {% block title %}Listado pedidos{% endblock %}
 
 {% block contenido %}
-
+<section>
+    <div class="container mt-3 mb-5">
+        <h2 class="border-bottom">Listado de Pedidos</h2>
+        <div class="row">
+            {% for pedido in pedidos %}
+            <div class="col-md-6">
+                <div class="card border-primary mb-3">
+                    <div class="card-header bg-dark text-white">
+                        <h4 class="mb-0">Pedido #{{ pedido.id }}</h4>
+                    </div>
+                    <div class="card-body">
+                        <h5 class="card-title">Estado: {{ pedido.estado }}</h5>
+                        <p class="card-text">
+                            <strong>Usuario:</strong> {{ pedido.usuario.username }}<br>
+                            <strong>Producto:</strong> {% for detalle in pedido.detalles.all %}{{ detalle.celular.modelo }} {% endfor %}
+                        </p>
+                        <a href="{% url 'detallepedido' pedido.id %}" class="btn btn-dark">Ver Detalles</a>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+</section>
 {% endblock contenido %}


### PR DESCRIPTION
feat: agregar vista de listado de pedidos en panel de administración

Se incorporó plantilla para mostrar los pedidos de clientes:

    Extiende de mobilemart/baseadmin.html y carga etiquetas static.

    Define el bloque title como “Listado pedidos”.

    En bloque contenido, añade sección con tabla de tarjetas Bootstrap que muestran cada pedido.

    Itera sobre pedidos con {% for pedido in pedidos %}, generando una card por pedido en un grid de dos columnas (col-md-6).

    Cada card incluye header estilizado (bg-dark text-white) con número de pedido, y cuerpo con estado, usuario y lista de productos asociados (pedido.detalles.all).

    Se añadió botón “Ver Detalles” que enlaza a la vista detallepedido pasando el pedido.id.