### PR TITLE
feat: agregar plantilla de reporte de pedidos en HTML

### DIFF
--- a/mobilemart/templates/mobilemart/reportepedidos.html
+++ b/mobilemart/templates/mobilemart/reportepedidos.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body { font-family: Arial; font-size: 12px; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #000; padding: 5px; }
+    </style>
+</head>
+<body>
+    <h2>Reporte de Pedidos</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Usuario</th>
+                <th>Estado</th>
+                <th>Fecha</th>
+                <th>Productos</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for pedido in pedidos %}
+            <tr>
+                <td>{{ pedido.id }}</td>
+                <td>{{ pedido.usuario.username }}</td>
+                <td>{{ pedido.estado }}</td>
+                <td>{{ pedido.fecha_pedido }}</td>
+                <td>
+                    {% for d in pedido.detalles.all %}
+                        {{ d.celular.modelo }}{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>
+


### PR DESCRIPTION
Se añadió nueva vista para generar reportes de pedidos:

    Se creó documento reportes_pedidos.html con declaración <!DOCTYPE html> y estilos inline (font-family: Arial; font-size: 12px;, tablas con bordes colapsados y celdas con padding).

    Incluye encabezado <h2>Reporte de Pedidos</h2> y tabla con columnas ID, Usuario, Estado, Fecha y Productos.

    Itera sobre pedidos con {% for pedido in pedidos %} para poblar cada fila con pedido.id, pedido.usuario.username, pedido.estado y pedido.fecha_pedido.

    En columna Productos, recorre pedido.detalles.all mostrando d.celular.modelo y separa items con comas usando {% if not forloop.last %}, {% endif %}.

    Asegura compatibilidad imprimible y claridad de datos para exportación o visualización administrativa.